### PR TITLE
Not generate a sample helmfile

### DIFF
--- a/kode
+++ b/kode
@@ -416,12 +416,6 @@ tasks:
       # | cloudwatch-logger -t "${log_group}" ${DEPLOYMENT_ID/stdout}
       EOS
 
-      cat <<EOS > helmfile.yaml
-      releases:
-      - name: foo
-        chart: stable/nginx
-      EOS
-
       chmod +x ${before_install} ${after_install}
 
       cd -


### PR DESCRIPTION
Please remove generation of a sample helmfile.
`kode deploy` overwrite a helmfile of target application by sample😱  