### PR TITLE
Deploy a codedeploy agent to a kodedeploy namespece

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -76,6 +76,7 @@ spec:
           subPath: credentials
         - name: cloudwatch-agent-conf
           mountPath: /etc/aws/amazon-cloudwatch-agent
+      serviceAccountName: kodedeploy
       volumes:
       - name: deployment-root
         emptyDir: {}

--- a/kode
+++ b/kode
@@ -273,23 +273,23 @@ tasks:
         EOS
 
       apply: &apply |
-        kubectl create namespace ${ns} --dry-run=$dryrun
+       kubectl --dry-run=$dryrun create namespace kodedeploy --dry-run=$dryrun
 
-        kubectl --dry-run=$dryrun --namespace ${ns} \
+        kubectl --dry-run=$dryrun --namespace kodedeploy \
           create secret generic --from-file=${etc_codedeploy_agent_conf_dir} $(basename $etc_codedeploy_agent_conf_dir)
 
-        kubectl --dry-run=$dryrun --namespace ${ns} \
+        kubectl --dry-run=$dryrun --namespace kodedeploy \
           create configmap --from-file="${opt_codedeploy_agent_conf_dir}" $(basename $opt_codedeploy_agent_conf_dir)
 
-        kubectl --dry-run=$dryrun --namespace ${ns} \
+        kubectl --dry-run=$dryrun --namespace kodedeploy \
           create secret generic --from-file="${aws_dir}" $(basename $aws_dir)
 
-        kubectl --dry-run=$dryrun --namespace ${ns} \
+        kubectl --dry-run=$dryrun --namespace kodedeploy \
           create configmap --from-file="${cloudwatch_agent_conf_dir}" $(basename $cloudwatch_agent_conf_dir)
 
-        kubectl --dry-run=$dryrun --namespace ${ns} apply -f deploy.yaml
+        kubectl --dry-run=$dryrun --namespace kodedeploy apply -f deploy.yaml
 
-        kubectl get secret,configmap,pod -n ${ns}
+        kubectl get secret,configmap,pod -n kodedeploy
 
     script:
     - |

--- a/serviceaccount.yaml
+++ b/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kodedeploy
+automountServiceAccountToken: true


### PR DESCRIPTION
__Before__
- aws-codedeploy-agent deploy at namespace that is for applications.
- aws-codedeploy-agent pod run by ServiceAccountName = `default`.

Additionally, pods have strong authority in many case(e.g. `helmfile sync` is need a role that can read/write pods). There is a risk that the entire cluster will be hijacked if there is a vulnerability in the application.

__After__
- aws-codedeploy-agent deploy at namespace `kodedeploy`.
- aws-codedeploy-agent pod run by ServiceAccountName = `kodedeploy`.

